### PR TITLE
Add ability to customize slider font

### DIFF
--- a/fluid-slider/src/main/kotlin/com/ramotion/fluidslider/FluidSlider.kt
+++ b/fluid-slider/src/main/kotlin/com/ramotion/fluidslider/FluidSlider.kt
@@ -202,7 +202,7 @@ class FluidSlider @JvmOverloads constructor(
      * Font resource used to render the slider's text
      */
     @FontRes
-    var fontId: Int? = null
+    var fontId: Int = -1
     set(value) {
         field = value
 
@@ -240,6 +240,7 @@ class FluidSlider @JvmOverloads constructor(
         val colorBarText: Int
         val colorLabelText: Int
         val duration: Long
+        val fontId: Int
 
         constructor(superState: Parcelable?,
                     position: Float,
@@ -250,7 +251,8 @@ class FluidSlider @JvmOverloads constructor(
                     colorBar: Int,
                     colorBarText: Int,
                     colorLabelText: Int,
-                    duration: Long) : super(superState) {
+                    duration: Long,
+                    fontId: Int) : super(superState) {
             this.position = position
             this.startText = startText
             this.endText = endText
@@ -260,6 +262,7 @@ class FluidSlider @JvmOverloads constructor(
             this.colorBarText = colorBarText
             this.colorLabelText = colorLabelText
             this.duration = duration
+            this.fontId = fontId
         }
 
         private constructor(parcel: Parcel) : super(parcel) {
@@ -272,6 +275,7 @@ class FluidSlider @JvmOverloads constructor(
             this.colorBarText = parcel.readInt()
             this.colorLabelText = parcel.readInt()
             this.duration = parcel.readLong()
+            this.fontId = parcel.readInt()
         }
 
         override fun writeToParcel(parcel: Parcel, i: Int) {
@@ -285,6 +289,7 @@ class FluidSlider @JvmOverloads constructor(
             parcel.writeInt(colorBarText)
             parcel.writeInt(colorLabelText)
             parcel.writeLong(duration)
+            parcel.writeInt(fontId)
         }
 
         override fun describeContents(): Int = 0
@@ -362,7 +367,7 @@ class FluidSlider @JvmOverloads constructor(
     override fun onSaveInstanceState(): Parcelable {
         return State(super.onSaveInstanceState(),
                 position, startText, endText, textSize,
-                colorBubble, colorBar, colorBarText, colorBubbleText, duration)
+                colorBubble, colorBar, colorBarText, colorBubbleText, duration, fontId)
     }
 
     override fun onRestoreInstanceState(state: Parcelable) {
@@ -377,6 +382,7 @@ class FluidSlider @JvmOverloads constructor(
             colorBarText = state.colorBarText
             colorBubbleText = state.colorLabelText
             duration = state.duration
+            fontId = state.fontId
         } else {
             super.onRestoreInstanceState(state)
         }

--- a/fluid-slider/src/main/kotlin/com/ramotion/fluidslider/FluidSlider.kt
+++ b/fluid-slider/src/main/kotlin/com/ramotion/fluidslider/FluidSlider.kt
@@ -12,6 +12,7 @@ import android.view.MotionEvent
 import android.view.View
 import android.view.ViewOutlineProvider
 import android.view.animation.OvershootInterpolator
+import androidx.annotation.FontRes
 import androidx.core.content.res.ResourcesCompat
 import com.ramotion.fluidslider.FluidSlider.Size.NORMAL
 import com.ramotion.fluidslider.FluidSlider.Size.SMALL
@@ -198,13 +199,16 @@ class FluidSlider @JvmOverloads constructor(
     var endTrackingListener: (() -> Unit)? = null
 
     /**
-     * Typeface used to render the slider's text
+     * Font resource used to render the slider's text
      */
-    var typeface: Typeface? = null
+    @FontRes
+    var fontId: Int? = null
     set(value) {
         field = value
-        paintText.typeface = value
-        invalidate()
+
+        paintText.typeface = value.takeIf { it != -1 }?.let {
+            ResourcesCompat.getFont(context, it)
+        }
     }
 
     @SuppressLint("NewApi")
@@ -319,9 +323,7 @@ class FluidSlider @JvmOverloads constructor(
                 val defaultBarHeight = if (a.getInteger(R.styleable.FluidSlider_size, 1) == 1) Size.NORMAL.value else Size.SMALL.value
                 barHeight = defaultBarHeight * density
 
-                typeface = a.getResourceId(R.styleable.FluidSlider_slider_font, -1).takeIf { it != -1 }?.let {
-                    ResourcesCompat.getFont(context, it)
-                }
+                fontId = a.getResourceId(R.styleable.FluidSlider_slider_font, -1)
             } finally {
                 a.recycle()
             }

--- a/fluid-slider/src/main/kotlin/com/ramotion/fluidslider/FluidSlider.kt
+++ b/fluid-slider/src/main/kotlin/com/ramotion/fluidslider/FluidSlider.kt
@@ -12,6 +12,7 @@ import android.view.MotionEvent
 import android.view.View
 import android.view.ViewOutlineProvider
 import android.view.animation.OvershootInterpolator
+import androidx.core.content.res.ResourcesCompat
 import com.ramotion.fluidslider.FluidSlider.Size.NORMAL
 import com.ramotion.fluidslider.FluidSlider.Size.SMALL
 import kotlin.math.*
@@ -196,6 +197,16 @@ class FluidSlider @JvmOverloads constructor(
      */
     var endTrackingListener: (() -> Unit)? = null
 
+    /**
+     * Typeface used to render the slider's text
+     */
+    var typeface: Typeface? = null
+    set(value) {
+        field = value
+        paintText.typeface = value
+        invalidate()
+    }
+
     @SuppressLint("NewApi")
     inner class OutlineProvider : ViewOutlineProvider() {
         override fun getOutline(v: View?, outline: Outline?) {
@@ -307,6 +318,10 @@ class FluidSlider @JvmOverloads constructor(
 
                 val defaultBarHeight = if (a.getInteger(R.styleable.FluidSlider_size, 1) == 1) Size.NORMAL.value else Size.SMALL.value
                 barHeight = defaultBarHeight * density
+
+                typeface = a.getResourceId(R.styleable.FluidSlider_slider_font, -1).takeIf { it != -1 }?.let {
+                    ResourcesCompat.getFont(context, it)
+                }
             } finally {
                 a.recycle()
             }

--- a/fluid-slider/src/main/kotlin/com/ramotion/fluidslider/FluidSlider.kt
+++ b/fluid-slider/src/main/kotlin/com/ramotion/fluidslider/FluidSlider.kt
@@ -209,6 +209,7 @@ class FluidSlider @JvmOverloads constructor(
         paintText.typeface = value.takeIf { it != -1 }?.let {
             ResourcesCompat.getFont(context, it)
         }
+        invalidate()
     }
 
     @SuppressLint("NewApi")

--- a/fluid-slider/src/main/res/values/attrs.xml
+++ b/fluid-slider/src/main/res/values/attrs.xml
@@ -15,5 +15,6 @@
             <enum name="small" value="0"/>
             <enum name="normal" value="1"/>
         </attr>
+        <attr name="slider_font" format="reference" />
     </declare-styleable>
 </resources>


### PR DESCRIPTION
This adds the ability to customize the slider's font through either the XML attribute `slider_font`, or through the `FluidSlider.typeface` property.

To see this new functionality in action, checkout the `font-test` branch in the `takoda-android` project. Alternatively, here are some screenshots:
### Before
![before](https://user-images.githubusercontent.com/48688368/86972339-68467a00-c138-11ea-8aa6-419dd81d6073.png)

### After
![after](https://user-images.githubusercontent.com/48688368/86972443-8f9d4700-c138-11ea-9e12-ed37b36f7c82.png)

