### PR TITLE
Add ability to customize slider corner radius

### DIFF
--- a/fluid-slider/src/main/kotlin/com/ramotion/fluidslider/FluidSlider.kt
+++ b/fluid-slider/src/main/kotlin/com/ramotion/fluidslider/FluidSlider.kt
@@ -43,7 +43,7 @@ class FluidSlider @JvmOverloads constructor(
     }
 
     private companion object {
-        const val BAR_CORNER_RADIUS = 8
+        const val BAR_CORNER_RADIUS = 2
         const val BAR_VERTICAL_OFFSET = 1.5f
         const val BAR_INNER_HORIZONTAL_OFFSET = 0
 
@@ -330,6 +330,8 @@ class FluidSlider @JvmOverloads constructor(
                 barHeight = defaultBarHeight * density
 
                 fontId = a.getResourceId(R.styleable.FluidSlider_slider_font, -1)
+
+                barCornerRadius = a.getDimension(R.styleable.FluidSlider_corner_radius, BAR_CORNER_RADIUS * density)
             } finally {
                 a.recycle()
             }
@@ -338,6 +340,7 @@ class FluidSlider @JvmOverloads constructor(
             colorBubble = COLOR_LABEL
             textSize = TEXT_SIZE * density
             barHeight = size.value * density
+            barCornerRadius = BAR_CORNER_RADIUS * density
         }
 
         desiredWidth = (barHeight * SLIDER_WIDTH).toInt()
@@ -352,7 +355,6 @@ class FluidSlider @JvmOverloads constructor(
         metaballRiseDistance = barHeight * METABALL_RISE_DISTANCE
 
         barVerticalOffset = barHeight * BAR_VERTICAL_OFFSET
-        barCornerRadius = BAR_CORNER_RADIUS * density
         barInnerOffset = BAR_INNER_HORIZONTAL_OFFSET * density
         textOffset = TEXT_OFFSET * density
     }

--- a/fluid-slider/src/main/kotlin/com/ramotion/fluidslider/FluidSlider.kt
+++ b/fluid-slider/src/main/kotlin/com/ramotion/fluidslider/FluidSlider.kt
@@ -91,7 +91,6 @@ class FluidSlider @JvmOverloads constructor(
     private val textOffset: Float
 
     private val barVerticalOffset: Float
-    private val barCornerRadius: Float
     private val barInnerOffset: Float
 
     private val rectBar = RectF()
@@ -212,6 +211,11 @@ class FluidSlider @JvmOverloads constructor(
         invalidate()
     }
 
+    /**
+     * The radius (in pixels) of the circle used to round this slider's corners
+     */
+    var barCornerRadius: Float
+
     @SuppressLint("NewApi")
     inner class OutlineProvider : ViewOutlineProvider() {
         override fun getOutline(v: View?, outline: Outline?) {
@@ -242,6 +246,7 @@ class FluidSlider @JvmOverloads constructor(
         val colorLabelText: Int
         val duration: Long
         val fontId: Int
+        val barCornerRadius: Float
 
         constructor(superState: Parcelable?,
                     position: Float,
@@ -253,7 +258,8 @@ class FluidSlider @JvmOverloads constructor(
                     colorBarText: Int,
                     colorLabelText: Int,
                     duration: Long,
-                    fontId: Int) : super(superState) {
+                    fontId: Int,
+                    barCornerRadius: Float) : super(superState) {
             this.position = position
             this.startText = startText
             this.endText = endText
@@ -264,6 +270,7 @@ class FluidSlider @JvmOverloads constructor(
             this.colorLabelText = colorLabelText
             this.duration = duration
             this.fontId = fontId
+            this.barCornerRadius = barCornerRadius
         }
 
         private constructor(parcel: Parcel) : super(parcel) {
@@ -277,6 +284,7 @@ class FluidSlider @JvmOverloads constructor(
             this.colorLabelText = parcel.readInt()
             this.duration = parcel.readLong()
             this.fontId = parcel.readInt()
+            this.barCornerRadius = parcel.readFloat()
         }
 
         override fun writeToParcel(parcel: Parcel, i: Int) {
@@ -291,6 +299,7 @@ class FluidSlider @JvmOverloads constructor(
             parcel.writeInt(colorLabelText)
             parcel.writeLong(duration)
             parcel.writeInt(fontId)
+            parcel.writeFloat(barCornerRadius)
         }
 
         override fun describeContents(): Int = 0
@@ -370,7 +379,7 @@ class FluidSlider @JvmOverloads constructor(
     override fun onSaveInstanceState(): Parcelable {
         return State(super.onSaveInstanceState(),
                 position, startText, endText, textSize,
-                colorBubble, colorBar, colorBarText, colorBubbleText, duration, fontId)
+                colorBubble, colorBar, colorBarText, colorBubbleText, duration, fontId, barCornerRadius)
     }
 
     override fun onRestoreInstanceState(state: Parcelable) {
@@ -386,6 +395,7 @@ class FluidSlider @JvmOverloads constructor(
             colorBubbleText = state.colorLabelText
             duration = state.duration
             fontId = state.fontId
+            barCornerRadius = state.barCornerRadius
         } else {
             super.onRestoreInstanceState(state)
         }

--- a/fluid-slider/src/main/res/values/attrs.xml
+++ b/fluid-slider/src/main/res/values/attrs.xml
@@ -16,5 +16,6 @@
             <enum name="normal" value="1"/>
         </attr>
         <attr name="slider_font" format="reference" />
+        <attr name="corner_radius" format="dimension" />
     </declare-styleable>
 </resources>


### PR DESCRIPTION
This PR adds the ability to customize the slider's corner radius through either the XML attribute `corner_radius` or the `FluidSlider.barCornerRadius` property. 

Previously this fork manually changed the radius from 2dp->8dp in code, but Doc requested that we properly implement corner customization so that it can be contributed back to the [original repository](https://github.com/Ramotion/fluid-slider-android), as we don't want to maintain our own fork.